### PR TITLE
fix: update security workflow with appropriate scanners

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,12 +17,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
         with:
-          languages: javascript, python  # Adjust based on your repository languages
-      
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+          scandir: './scripts'
+          severity: warning  # Report warnings and errors
+          
+      - name: Run Trivy Config Scanner
+        uses: aquasecurity/trivy-action@master
         with:
-          category: "/language:javascript"  # Adjust based on your repository languages
+          scan-type: 'config'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          
+      - name: Upload Trivy scan results
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
- Add workflow_dispatch event to security workflow
- Add workflow_dispatch event to CI workflow
- Add pr_body.md to gitignore
- Document PR description approach in .cursorrules
- Update .chezmoiignore with additional files
- Allows manual triggering of both workflows for testing

## What does this PR do?

Updates the security workflow to use more appropriate scanners for a dotfiles repository:

- Adds ShellCheck for scanning shell scripts
- Adds Trivy Config Scanner for scanning configuration files
- Removes CodeQL which was focused on JavaScript/Python

## Why are we doing this?

The previous security workflow was using CodeQL which is more appropriate for application code repositories. Since this is a dotfiles repository, we need scanners that are better suited for configuration files and shell scripts.

## How should this be manually tested?

1. The workflow can be triggered manually using the Actions tab
2. It should scan shell scripts in the repository using ShellCheck
3. It should scan configuration files using Trivy

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related tickets & documents

- Related to #13 which added manual trigger support 