### PR TITLE
fix: fix asdf lazy loading variable scope issue

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -77,11 +77,12 @@ fi
 # Note: Migrated from nodenv to asdf for unified version management
 _asdf_path="${HOMEBREW_PREFIX}/opt/asdf/libexec/asdf.sh"
 if [ -f "$_asdf_path" ]; then
-    _asdf_cmds=(node npm npx python python3 ruby gem rustc cargo go)
+    _asdf_cmds=(node npm npx vercel wrangler python python3 ruby gem rustc cargo go)
     _asdf_load() {
         unset -f $_asdf_cmds
         unset _asdf_cmds
         . "$_asdf_path"
+        unset _asdf_path
     }
     # 'command' ensures PATH lookup after asdf adds shims to PATH
     for cmd in $_asdf_cmds; do
@@ -89,7 +90,6 @@ if [ -f "$_asdf_path" ]; then
     done
     unset cmd
 fi
-unset _asdf_path _asdf_cmds 2>/dev/null
 
 # =============================================================================
 # Shell Configuration


### PR DESCRIPTION
## Summary
- Fix asdf lazy loading bug where variables were unset too early
- Move `_asdf_path` cleanup inside `_asdf_load()` function to fix "no such file or directory" error
- Remove premature `unset _asdf_path _asdf_cmds` that broke lazy loading
- Add `vercel` and `wrangler` to lazy load trigger list

## Root Cause
The lazy loading code had `unset _asdf_path _asdf_cmds` at shell initialization (line 92), but the `_asdf_load()` function needed these variables when called later by commands. This caused:
1. `_asdf_load:unset:1: not enough arguments` (from `unset -f $_asdf_cmds` with empty var)
2. `_asdf_load:.:3: no such file or directory` (from `. "$_asdf_path"` with empty var)

## Test plan
- [x] `npm -g list` works without errors
- [x] `vercel --version` works directly
- [x] `./test.sh` passes all tests
- [x] asdf-managed tools (node, npm, python) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
