### PR TITLE
feat: add media server power settings for halfmoon

### DIFF
--- a/dot_my/executable_dot_macos
+++ b/dot_my/executable_dot_macos
@@ -168,6 +168,19 @@ sudo rm -f /private/var/vm/sleepimage 2>/dev/null || true
 sudo touch /private/var/vm/sleepimage 2>/dev/null || true
 sudo chflags uchg /private/var/vm/sleepimage 2>/dev/null || true
 
+######################## Media Server Settings (halfmoon) ####################
+
+if [ "$(hostname -s)" = "halfmoon" ]; then
+  # Never sleep — media server must stay awake even without Plex running
+  sudo pmset -a sleep 0
+
+  # Never spin down disks — prevents NFS mount drops
+  sudo pmset -a disksleep 0
+
+  # Download updates but don't auto-install — prevents surprise reboots
+  sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
+fi
+
 ########################### Screen Settings #################################
 
 # Require password immediately after sleep or screen saver begins


### PR DESCRIPTION
## Summary

- Never sleep (`pmset sleep 0`) — keeps machine awake even without Plex running
- Never spin down disks (`pmset disksleep 0`) — prevents NFS mount drops
- Disable automatic macOS update installs — prevents surprise reboots

All settings are scoped to `halfmoon` hostname so they don't affect other machines.

## Test plan

- [ ] Run `~/.my/.macos` on halfmoon and verify pmset settings with `pmset -g`
- [ ] Verify other machines are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)